### PR TITLE
Implement LETTA_MODE with whisper as default

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-subconscious",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A subconscious for Claude Code. A Letta agent watches your sessions, accumulates context, and whispers guidance back.",
   "author": {
     "name": "Letta",

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Get your API key from [app.letta.com](https://app.letta.com).
 ### Optional
 
 ```bash
+export LETTA_MODE="whisper"    # Default. Set to "off" to disable
 export LETTA_AGENT_ID="agent-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 export LETTA_BASE_URL="http://localhost:8283"  # For self-hosted Letta
 export LETTA_MODEL="anthropic/claude-sonnet-4-5"  # Model override
@@ -112,11 +113,21 @@ export LETTA_HOME="$HOME"      # Consolidate .letta state to ~/.letta/
 export LETTA_PROJECT="$HOME"   # Consolidate CLAUDE.md to ~/.claude/CLAUDE.md
 ```
 
+- `LETTA_MODE` - Set to `off` to disable all hooks. Defaults to `whisper` (stdout injection). See [Modes](#modes) below.
 - `LETTA_AGENT_ID` - If not set, the plugin automatically imports a default "Subconscious" agent on first use.
 - `LETTA_BASE_URL` - For self-hosted Letta servers. Defaults to `https://api.letta.com`.
 - `LETTA_MODEL` - Override the agent's model. Optional - the plugin auto-detects and selects from available models. See [Model Configuration](#model-configuration) below.
 - `LETTA_HOME` - Base directory for plugin state files. Creates `{LETTA_HOME}/.letta/claude/` for session data and conversation mappings. Defaults to current working directory. Set to `$HOME` to consolidate all state in one location.
-- `LETTA_PROJECT` - Base directory for CLAUDE.md. Creates `{LETTA_PROJECT}/.claude/CLAUDE.md` for memory blocks. Defaults to current project directory. Set to `$HOME` to use a single global file that Claude Code discovers via path-walking.
+### Modes
+
+The `LETTA_MODE` environment variable controls the plugin:
+
+| Mode | Behavior |
+|------|----------|
+| **`whisper`** (default) | Full blocks on first prompt, diffs + messages after. Never writes to CLAUDE.md. |
+| **`off`** | Disable all hooks. Agent still exists but won't observe or inject anything. |
+
+Subconscious **never writes to CLAUDE.md**. All memory is injected via stdout into the prompt context. If you have an existing CLAUDE.md with `<letta>` content from an older version, it will be cleaned up automatically.
 
 ### Agent Resolution Order
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-subconscious",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A subconscious for Claude Code. A Letta agent watches your sessions, accumulates context, and whispers guidance back.",
   "author": "Letta <hello@letta.com> (https://letta.com)",
   "license": "MIT",

--- a/scripts/pretool_sync.ts
+++ b/scripts/pretool_sync.ts
@@ -22,6 +22,7 @@ import {
   saveSyncState,
   lookupConversation,
   SyncState,
+  getMode,
   LETTA_API_BASE,
 } from './conversation_utils.js';
 
@@ -251,6 +252,11 @@ function formatOutput(
  * Main function
  */
 async function main(): Promise<void> {
+  const mode = getMode();
+  if (mode === 'off') {
+    process.exit(0);
+  }
+
   const apiKey = process.env.LETTA_API_KEY;
   
   if (!apiKey) {

--- a/scripts/send_messages_to_letta.ts
+++ b/scripts/send_messages_to_letta.ts
@@ -35,6 +35,7 @@ import {
   getSyncStateFile,
   SyncState,
   LogFn,
+  getMode,
 } from './conversation_utils.js';
 
 // ESM-compatible __dirname
@@ -475,6 +476,13 @@ Write your response as if speaking directly to Claude Code.
 async function main(): Promise<void> {
   log('='.repeat(60));
   log('send_messages_to_letta.ts started');
+
+  const mode = getMode();
+  log(`Mode: ${mode}`);
+  if (mode === 'off') {
+    log('Mode is off, exiting');
+    process.exit(0);
+  }
   
   // Get environment variables
   const apiKey = process.env.LETTA_API_KEY;


### PR DESCRIPTION
## Summary

- **Default mode changed to `whisper`** — all memory blocks injected via stdout per-prompt, nothing written to CLAUDE.md
- **`cleanLettaFromClaudeMd()`** strips existing `<letta>` sections on first whisper-mode run (16K → 0 bytes)
- **`formatAllBlocksForStdout()`** injects full blocks on first prompt, diffs thereafter
- **Three modes**: `whisper` (default), `full` (legacy CLAUDE.md behavior), `off` (disable hooks)
- **All hooks** (`sync_letta_memory`, `session_start`, `pretool_sync`, `send_messages_to_letta`) are mode-aware

Fixes #14, addresses #13

### Before vs After

| | Before | After (whisper) |
|---|--------|----------------|
| CLAUDE.md | 6K-49K+ chars (all memory blocks) | 0 (cleaned up) |
| Stdout injection | Diffs + messages only | Full blocks (1st prompt) → diffs + messages |
| Cross-project contamination | Yes | No |

### Modes

| Mode | CLAUDE.md | Stdout | Default? |
|------|-----------|--------|----------|
| `whisper` | Nothing | Full blocks → diffs + messages | **Yes** |
| `full` | All memory blocks | Diffs + messages | No |
| `off` | Nothing | Nothing | No |

## Test plan

- [x] `LETTA_MODE=whisper` — blocks injected via stdout, no CLAUDE.md write
- [x] `LETTA_MODE=whisper` with existing CLAUDE.md — `<letta>` section stripped (16K → 18 bytes)
- [x] `LETTA_MODE=full` — writes blocks to CLAUDE.md (legacy behavior preserved)
- [x] `LETTA_MODE=off` — all hooks exit silently
- [ ] Live test with Claude Code session

Written by Cameron ◯ Letta Code

"Perfection is achieved, not when there is nothing more to add, but when there is nothing left to take away." - Antoine de Saint-Exupéry