### PR TITLE
feat: add MiniMax as supported model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ When the agent's model isn't available, the plugin selects from available models
 4. `openai/gpt-5.2` (flagship fallback)
 5. `google_ai/gemini-3-flash` (Google's balanced option)
 6. `google_ai/gemini-2.5-flash` (fallback)
-7. First available model on the server
+7. `minimax/MiniMax-M2.7` (MiniMax flagship, 1M context)
+8. `minimax/MiniMax-M2.7-highspeed` (MiniMax fast option)
+9. First available model on the server
 
 #### Manual Override
 
@@ -206,6 +208,7 @@ The model handle format is `provider/model`. Common options:
 | `openai` | `gpt-5.2`, `gpt-5-nano`, `gpt-4.1-mini` |
 | `anthropic` | `claude-sonnet-4-5`, `claude-opus-4-5`, `claude-haiku-4-5` |
 | `google_ai` | `gemini-3-flash`, `gemini-2.5-flash`, `gemini-2.5-pro` |
+| `minimax` | `MiniMax-M2.7` (1M context, strong tool use), `MiniMax-M2.7-highspeed` |
 | `zai` | `glm-5` (Letta Cloud default, free) |
 
 If `LETTA_MODEL` is set but not available on the server, the plugin will warn you and fall back to auto-selection.

--- a/scripts/agent_config.test.ts
+++ b/scripts/agent_config.test.ts
@@ -106,6 +106,8 @@ const SAMPLE_MODELS = [
   { model: 'gemini-3-pro-preview', name: 'gemini-3-pro-preview', provider_type: 'google_ai', handle: 'google_ai/gemini-3-pro-preview' },
   { model: 'gemini-3-pro-preview', name: 'gemini-3-pro-preview', provider_type: 'google_ai', handle: 'gem1/gemini-3-pro-preview' },
   { model: 'gpt-5.2', name: 'gpt-5.2', provider_type: 'openai', handle: 'openai/gpt-5.2' },
+  { model: 'MiniMax-M2.7', name: 'MiniMax-M2.7', provider_type: 'minimax', handle: 'minimax/MiniMax-M2.7' },
+  { model: 'MiniMax-M2.7-highspeed', name: 'MiniMax-M2.7-highspeed', provider_type: 'minimax', handle: 'minimax/MiniMax-M2.7-highspeed' },
 ];
 
 describe('findModel', () => {
@@ -138,6 +140,31 @@ describe('findModel', () => {
 
   it('should return null for empty models list', () => {
     expect(findModel([], 'anthropic/claude-sonnet-4-5')).toBeNull();
+  });
+
+  it('should find MiniMax model by exact handle', () => {
+    const result = findModel(SAMPLE_MODELS, 'minimax/MiniMax-M2.7');
+    expect(result).not.toBeNull();
+    expect(result!.handle).toBe('minimax/MiniMax-M2.7');
+    expect(result!.provider_type).toBe('minimax');
+  });
+
+  it('should find MiniMax highspeed model by handle', () => {
+    const result = findModel(SAMPLE_MODELS, 'minimax/MiniMax-M2.7-highspeed');
+    expect(result).not.toBeNull();
+    expect(result!.handle).toBe('minimax/MiniMax-M2.7-highspeed');
+  });
+
+  it('should find MiniMax model case-insensitively', () => {
+    const result = findModel(SAMPLE_MODELS, 'Minimax/minimax-m2.7');
+    expect(result).not.toBeNull();
+    expect(result!.provider_type).toBe('minimax');
+  });
+
+  it('should find MiniMax model by bare model name', () => {
+    const result = findModel(SAMPLE_MODELS, 'MiniMax-M2.7');
+    expect(result).not.toBeNull();
+    expect(result!.provider_type).toBe('minimax');
   });
 });
 
@@ -193,5 +220,28 @@ describe('buildLlmConfig', () => {
     expect(config.model).toBe('gpt-5.2');
     expect(config.handle).toBe('openai/gpt-5.2');
     expect(config.provider_name).toBe('openai');
+  });
+
+  it('should build correct config for MiniMax model', () => {
+    const config = buildLlmConfig('minimax/MiniMax-M2.7', SAMPLE_MODELS, undefined);
+    expect(config.model).toBe('MiniMax-M2.7');
+    expect(config.handle).toBe('minimax/MiniMax-M2.7');
+    expect(config.provider_name).toBe('minimax');
+    expect(config.model_endpoint_type).toBe('minimax');
+  });
+
+  it('should build correct config for MiniMax highspeed model', () => {
+    const config = buildLlmConfig('minimax/MiniMax-M2.7-highspeed', SAMPLE_MODELS, undefined);
+    expect(config.model).toBe('MiniMax-M2.7-highspeed');
+    expect(config.handle).toBe('minimax/MiniMax-M2.7-highspeed');
+    expect(config.provider_name).toBe('minimax');
+  });
+
+  it('should preserve existing settings when switching to MiniMax', () => {
+    const current = { model: 'claude-sonnet-4-5', context_window: 200000, temperature: 0.5 };
+    const config = buildLlmConfig('minimax/MiniMax-M2.7', SAMPLE_MODELS, current);
+    expect(config.model).toBe('MiniMax-M2.7');
+    expect(config.context_window).toBe(200000);
+    expect(config.temperature).toBe(0.5);
   });
 });

--- a/scripts/agent_config.ts
+++ b/scripts/agent_config.ts
@@ -33,6 +33,8 @@ const PREFERRED_MODELS = [
   'openai/gpt-5.2',              // Flagship fallback
   'google_ai/gemini-3-flash',    // Google's balanced option
   'google_ai/gemini-2.5-flash',  // Fallback
+  'minimax/MiniMax-M2.7',        // MiniMax flagship, 1M context, strong tool use
+  'minimax/MiniMax-M2.7-highspeed', // MiniMax fast option
 ];
 
 interface Config {


### PR DESCRIPTION
## Summary

- Add [MiniMax](https://www.minimax.io) M2.7 and M2.7-highspeed models to the `PREFERRED_MODELS` auto-selection list in `agent_config.ts`
- Add MiniMax to the provider table and auto-selection priority list in the README
- Add 7 unit tests covering MiniMax model lookup (exact handle, case-insensitive, bare name) and `buildLlmConfig` construction

MiniMax M2.7 offers 1M token context and strong tool-use capabilities, making it a viable option for users who configure MiniMax as a provider on their Letta server (via OpenAI-compatible API).

## Test plan

- [x] All 44 existing + new tests pass (`npx vitest run`)
- [ ] Verify MiniMax model auto-selection when configured on a Letta server
- [ ] Verify `LETTA_MODEL=minimax/MiniMax-M2.7` override works correctly