### PR TITLE
fix: guard /dev/tty with existsSync to prevent ENXIO on Node v25+

### DIFF
--- a/scripts/session_start.ts
+++ b/scripts/session_start.ts
@@ -255,8 +255,10 @@ async function main(): Promise<void> {
   // Try to open TTY for user-visible output (bypasses Claude's capture)
   let tty: fs.WriteStream | null = null;
   try {
-    tty = fs.createWriteStream('/dev/tty');
-    tty.on('error', () => { tty = null; }); // Handle async ENXIO when /dev/tty unavailable
+    if (fs.existsSync('/dev/tty')) {
+      tty = fs.createWriteStream('/dev/tty');
+      tty.on('error', () => { tty = null; });
+    }
   } catch {
     // TTY not available (e.g., non-interactive session)
   }


### PR DESCRIPTION
## Summary

- Adds `fs.existsSync('/dev/tty')` guard before creating the WriteStream in `session_start.ts`
- Prevents `ENXIO: no such device or address` crash in headless environments (Claude Code hooks) on Node v25+

## Problem

The existing `.on('error')` handler (added in a previous fix) is not sufficient on Node v25 — the async error can fire before the handler is attached, causing an unhandled `EventEmitter` error that crashes the `SessionStart` hook.

Users see `SessionStart:resume hook error` on every session start.

## Fix

```typescript
// Before (crashes on Node v25 in headless env)
tty = fs.createWriteStream('/dev/tty');
tty.on('error', () => { tty = null; });

// After (safe)
if (fs.existsSync('/dev/tty')) {
  tty = fs.createWriteStream('/dev/tty');
  tty.on('error', () => { tty = null; });
}
```

## Test plan

- [x] Verified fix locally on Node v25.0.0 / macOS Darwin 25.3.0
- [x] `SessionStart:resume hook error` no longer appears after restart

Fixes #44