### PR TITLE
fix: avoid mutating external agent memfs state

### DIFF
--- a/scripts/agent_config.ts
+++ b/scripts/agent_config.ts
@@ -530,6 +530,7 @@ async function importDefaultAgent(apiKey: string): Promise<string> {
 export async function getAgentId(apiKey: string, log: (msg: string) => void = console.log): Promise<string> {
   let agentId: string;
   let config = readConfig();
+  let agentSource: 'env' | 'saved' | 'imported';
   
   // 1. Check environment variable
   const envAgentId = process.env.LETTA_AGENT_ID;
@@ -542,6 +543,7 @@ export async function getAgentId(apiKey: string, log: (msg: string) => void = co
     }
     log(`Using agent ID from LETTA_AGENT_ID: ${envAgentId}`);
     agentId = envAgentId;
+    agentSource = 'env';
   }
   // 2. Check saved config
   else if (config.agentId) {
@@ -552,22 +554,36 @@ export async function getAgentId(apiKey: string, log: (msg: string) => void = co
       // Fall through to import default agent
       agentId = await importAndSaveAgent(apiKey, log);
       config = readConfig(); // Reload config after import
+      agentSource = 'imported';
     } else {
       log(`Using saved agent ID: ${config.agentId}`);
       agentId = config.agentId;
+      agentSource = 'saved';
     }
   }
   // 3. Import default agent
   else {
     agentId = await importAndSaveAgent(apiKey, log);
     config = readConfig(); // Reload config after import
+    agentSource = 'imported';
   }
   
-  // 4. Ensure required tags are present (for memory + origin tracking)
-  try {
-    await ensureRequiredAgentTags(apiKey, agentId, log);
-  } catch (error) {
-    log(`Warning: Could not ensure required tags: ${error}`);
+  // 4. Ensure required tags are present only for Subconscious-managed agents.
+  //
+  // A user-supplied LETTA_AGENT_ID may point at a normal Letta Code agent with
+  // its own MemFS repo. Patching tags on that external agent is surprisingly
+  // heavyweight: if the outgoing tag list includes git-memory-enabled, the
+  // server's update path may run git-memory initialization/backfill even when
+  // we are only adding an origin marker. Treat env-provided agents as external
+  // and avoid mutating their tags here.
+  if (agentSource !== 'env') {
+    try {
+      await ensureRequiredAgentTags(apiKey, agentId, log);
+    } catch (error) {
+      log(`Warning: Could not ensure required tags: ${error}`);
+    }
+  } else {
+    log('Using external LETTA_AGENT_ID; skipping Subconscious tag reconciliation');
   }
 
   // 5. Ensure model is available (auto-select if not)

--- a/scripts/send_worker_sdk.ts
+++ b/scripts/send_worker_sdk.ts
@@ -54,6 +54,11 @@ async function sendViaSdk(payload: SdkPayload): Promise<boolean> {
     skillSources: [],          // Sub doesn't need skills
     systemInfoReminder: false, // reduce noise
     sleeptime: { trigger: 'off' }, // don't recurse sleeptime
+    // The worker only needs to deliver a transcript to an existing Letta
+    // conversation. It should not clone/pull/reconcile the agent's MemFS repo
+    // on every Claude Code Stop hook: doing so can interact badly with a
+    // user-supplied LETTA_AGENT_ID whose memory is actively managed elsewhere.
+    memfsStartup: 'skip',
   };
 
   if (payload.sdkToolsMode === 'off') {


### PR DESCRIPTION
## Summary
- Treat `LETTA_AGENT_ID` as an external agent and skip Subconscious tag reconciliation for it.
- Start the async SDK transcript worker with `memfsStartup: "skip"` so Stop hooks do not clone/pull/reconcile MemFS.
- Reduce the chance that Claude Subconscious triggers git-memory backfills on Letta Code agents managed elsewhere.

## Test plan
- [ ] Not run locally: `node` is currently failing to load `/opt/homebrew/opt/simdjson/lib/libsimdjson.31.dylib` in this environment.
- [ ] Code review of the two affected paths.

👾 Generated with [Letta Code](https://letta.com)