### PR TITLE
fix: replace deprecated llm_config PATCH with model + context_window_limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Deprecated `llm_config` PATCH shape** — `updateAgentModel()` was sending `{ llm_config: {...} }` as the agent PATCH body. Letta now rejects that with HTTP 400 ("The `llm_config` field is deprecated and no longer accepted. Use the `model` field instead."). The session-start model/context-window sync therefore failed silently on every Claude Code launch, leaving `LETTA_MODEL` / `LETTA_CONTEXT_WINDOW` env overrides un-applied — agents stayed pinned to whatever they last had server-side. Switched to the new top-level `model` + `context_window_limit` shape.
+
 ## [1.1.0] - 2026-01-28
 
 ### Added

--- a/scripts/agent_config.ts
+++ b/scripts/agent_config.ts
@@ -433,11 +433,17 @@ export function buildLlmConfig(
 }
 
 /**
- * Update agent's model configuration via the llm_config PATCH.
+ * Update agent's model configuration via the agent PATCH endpoint.
  *
- * Uses `{ llm_config: {...} }` instead of `{ model: "..." }` because the
- * top-level model PATCH resets context_window to a server-side default.
- * Sending the full llm_config preserves context_window and other settings.
+ * Letta deprecated the `llm_config` request body (HTTP 400:
+ * "The `llm_config` field is deprecated and no longer accepted. Use the `model`
+ * field instead."). The replacement shape is top-level `model` plus
+ * `context_window_limit` — the latter explicitly avoids the old footgun where
+ * a bare `{ model }` PATCH reset context_window to a server default.
+ *
+ * buildLlmConfig() is kept for callers that still need the resolved
+ * provider/model metadata; we just pull the two server-accepted fields out of
+ * it and send those.
  */
 async function updateAgentModel(
   apiKey: string,
@@ -453,8 +459,12 @@ async function updateAgentModel(
 
   const llmConfig = buildLlmConfig(modelHandle, models, currentConfig);
 
-  if (llmConfig.context_window && llmConfig.context_window !== currentConfig?.context_window) {
-    log(`Including context_window: ${llmConfig.context_window}`);
+  const body: Record<string, unknown> = { model: modelHandle };
+  if (typeof llmConfig.context_window === 'number') {
+    body.context_window_limit = llmConfig.context_window;
+    if (llmConfig.context_window !== currentConfig?.context_window) {
+      log(`Including context_window: ${llmConfig.context_window}`);
+    }
   }
 
   const response = await fetch(url, {
@@ -463,7 +473,7 @@ async function updateAgentModel(
       'Authorization': `Bearer ${apiKey}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ llm_config: llmConfig }),
+    body: JSON.stringify(body),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary

`updateAgentModel()` was sending the now-deprecated `{ llm_config: {...} }` shape on the agent PATCH endpoint. The Letta API rejects it with HTTP 400:

> The `llm_config` field is deprecated and no longer accepted. Use the `model` field instead.

This means the session-start model/context-window sync has been failing silently on every Claude Code launch. Users who set `LETTA_MODEL` or `LETTA_CONTEXT_WINDOW` see the override land in the startup log lines, but it never persists — `ensureModelAvailable()` catches the thrown error and emits a `Warning: Could not verify model availability` line. Agents stay pinned to whatever the server last had.

## Reproduction

```bash
export LETTA_CONTEXT_WINDOW=1048576
claude   # any session
```

Look at the SessionStart hook output. You'll see:

```
Updating context_window to 1048576 (was 128000)
Updating agent model to: anthropic/claude-sonnet-4-6
Including context_window: 1048576
Warning: Could not verify model availability: Error: Failed to update agent model: 400 {"detail":"The `llm_config` field is deprecated and no longer accepted. Use the `model` field instead."}
```

Verify with `GET /v1/agents/<id>` — `llm_config.context_window` is still the old value.

## Fix

Switched the PATCH body to the new top-level shape:

```ts
{ model: "<handle>", context_window_limit: <int> }
```

`context_window_limit` is sent only when `buildLlmConfig()` resolved a numeric value, which preserves the original intent of avoiding bare `{ model }` PATCHes (those reset `context_window` to a server default — the exact footgun the old code was working around).

`buildLlmConfig()` itself is **unchanged**. Its returned object is still useful for provider/model metadata, and keeping it intact preserves all 32 existing unit tests around env-var handling and provider resolution.

## Test plan

- [x] `npx vitest run` → 37 passed, 0 failed
- [x] Manually verified the new shape works against `api.letta.com`:
  ```
  PATCH /v1/agents/<id>  {"model":"anthropic/claude-sonnet-4-6","context_window_limit":1048576}
  → HTTP 200, agent.llm_config.context_window now reports 1048576
  ```

## Notes

- No new tests added because `updateAgentModel()` was already untested (it requires a live server). Happy to add a mocked-fetch test if maintainers want one.
- The `Warning: Could not verify model availability` startup log will go away for affected users after this lands.