### PR TITLE
fix(api): message fetch limit exceeds API cap, silencing the subconscious

### DIFF
--- a/scripts/sync_letta_memory.ts
+++ b/scripts/sync_letta_memory.ts
@@ -197,9 +197,11 @@ async function fetchAssistantMessages(
   }
 
   // Use a high limit because Letta returns multiple entries per logical message
-  // (hidden_reasoning + assistant_message pairs), so limit=50 may not reach newest messages
+  // (hidden_reasoning + assistant_message pairs), so limit=50 may not reach newest messages.
+  // NOTE: 200 is the maximum the API accepts — higher values are rejected with
+  // HTTP 422, which the !response.ok branch below swallows into "no new messages".
   const url = buildLettaApiUrl(`/conversations/${conversationId}/messages`, {
-    limit: 300,
+    limit: 200,
   });
 
   const response = await fetch(url, {


### PR DESCRIPTION
The subconscious currently cannot deliver any message to Claude Code when running against Letta Cloud. It installs, connects, receives transcripts, and replies normally — but no reply ever reaches the session.

## Cause

`fetchAssistantMessages` in `scripts/sync_letta_memory.ts` requests `limit: 300`:

```ts
const url = buildLettaApiUrl(`/conversations/${conversationId}/messages`, {
  limit: 300,
});
```

The API caps `limit` at **200** and rejects anything larger with **HTTP 422**:

```json
{"type": "less_than_equal", "loc": ["query", "limit"],
 "msg": "Input should be less than or equal to 200", "input": "300", "ctx": {"le": 200}}
```

The next branch swallows it:

```ts
if (!response.ok) {
  // Don't fail if we can't fetch messages, just return empty
  return { messages: [], lastMessageId: lastSeenMessageId };
}
```

So every fetch fails, every fetch is silently treated as "nothing new", and the `UserPromptSubmit` hook emits `<!-- No new messages from ... -->` on every single prompt.

The failure is invisible from the user side. There is no error, no warning, no degraded mode — the agent simply appears to have nothing to say. Users reasonably conclude the subconscious is uninteresting or broken rather than that delivery is failing.

## Reproduce

```bash
curl -s -o /dev/null -w "%{http_code}\n" \
  -H "Authorization: Bearer $LETTA_API_KEY" \
  "https://api.letta.com/v1/conversations/<conversation-id>/messages?limit=300"   # 422
  
curl -s -o /dev/null -w "%{http_code}\n" \
  -H "Authorization: Bearer $LETTA_API_KEY" \
  "https://api.letta.com/v1/conversations/<conversation-id>/messages?limit=200"   # 200
```

Alternatively: run any session, confirm via the API that the agent has produced `assistant_message` entries, and observe that the hook still reports no new messages.

## Origin

Introduced in 8adae7c, which raised the limit from 50 to 300. That change was incidental to the commit it rode in on (`fix(windows): eliminate console window flashes using PseudoConsole`), which is likely why it escaped review. `04c3423` later refactored the URL construction but preserved the value.

## Fix

Lower to 200 — the highest value the API accepts. This preserves the intent of the original bump (reach back past `hidden_reasoning`/tool entries to the newest `assistant_message`) while staying inside the cap. A comment is added so the ceiling is not re-raised later.

200 is comfortably sufficient in practice: the hook advances its `lastSeenMessageId` bookmark on every prompt, so the window only has to span a single turn, and a turn costs a handful of entries. If the bookmark ever did fall outside the window, `findIndex` returns `-1` and the code re-delivers rather than dropping — so the degradation is duplication, not silence.

## Scope

Verified against Letta Cloud (`api.letta.com`), where whisper delivery was restored on the first poll after the change. Self-hosted servers are **likely** affected identically — the rejection is a Pydantic validation error from the route definition rather than cloud-side configuration — but I have not tested a self-hosted instance directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)